### PR TITLE
QT fix

### DIFF
--- a/.licrc
+++ b/.licrc
@@ -1,0 +1,26 @@
+# .licrc
+#
+# IMPORTANT!: ALL SECTIONS ARE MANDATORY
+[licenses]
+# This indicates which are the only licenses that Licensebat will accept.
+# The rest will be flagged as not allowed.
+accepted = ["MIT", "MSC", "BSD"]
+# This will indicate which licenses are not accepted.
+# The rest will be accepted, except for the unknown licenses or dependencies without licenses.
+# unaccepted = ["LGPL"]
+# Note that only one of the previous options can be enabled at once. 
+# If both of them are informed, only accepted will be considered.
+
+[dependencies]
+# This will allow users to flag some dependencies so that Licensebat will not check for their license.
+ignored=["ignored_dep1", "ignored_dep2"]
+# If set to true, Licensebat will ignore the dev dependencies.
+ignore_dev_dependencies = true
+# If set to true, Licensebat will ignore the optional dependencies.
+ignore_optional_dependencies = true
+
+[behavior]
+# False by default, if true, it will only run the checks when one of the dependency files or the .licrc file has been modified.
+run_only_on_dependency_modification = true
+# False by default, if true, it will never block the build.
+do_not_block_pr = false

--- a/xlnt/include/xlnt/utils/numeric.hpp
+++ b/xlnt/include/xlnt/utils/numeric.hpp
@@ -165,6 +165,8 @@ public:
 
     double deserialise(const std::string &s, ptrdiff_t *len_converted) const
     {
+        std::locale saved_locale(setlocale(LC_NUMERIC, NULL));
+        setlocale(LC_NUMERIC, "C");
         assert(!s.empty());
         assert(len_converted != nullptr);
         char *end_of_convert;
@@ -172,6 +174,7 @@ public:
         {
             double d = strtod(s.c_str(), &end_of_convert);
             *len_converted = end_of_convert - s.c_str();
+            setlocale(LC_NUMERIC, saved_locale.name().c_str());
             return d;
         }
         char buf[30];
@@ -180,6 +183,7 @@ public:
         convert_pt_to_comma(buf, static_cast<size_t>(copy_end - buf));
         double d = strtod(buf, &end_of_convert);
         *len_converted = end_of_convert - buf;
+        setlocale(LC_NUMERIC, saved_locale.name().c_str());
         return d;
     }
 


### PR DESCRIPTION
On Unix/Linux Qt is configured to use the system locale settings by default. This may cause a locale conflict when converting a string to a numeric value.
Save the current locale and change the locale for LC_NUMERIC to C for converting a string to a number, to avoid locale conflicts.
https://doc.qt.io/qt-6/qcoreapplication.html#locale-settings